### PR TITLE
remove wrong support link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Tell us what feature, integration or UI tweak would rock your world. Just go [he
 2. Process description. What step(s) are needed to solve this issue?
 3. Expected outcome. What should your world (or Checkly) look like after using this function.
 
-💡 For general support requests and bug reports, please go to checklyhq.com/support
+💡 For general support requests and bug reports, please go to checklyhq.com and contact us via support chat - or just write to support@checklyhq.com
 
 <br>
 <br>


### PR DESCRIPTION
The old README sent users to checklyhq.com/support, which is not a page.