### PR TITLE
Link to the new kanban board.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 This roadmap contains all the tweaks, improvements and new features we plan for Checkly. Of course, things change and we may shuffle priorities at any time. At Checkly we learn A TON from talking to users, so don't hesitate to contact us with your ideas and feedback.
 
-Check the [Kanban board in this project](https://github.com/checkly/roadmap/projects/1) for an overview.
+Check the [Kanban board in this project](https://github.com/orgs/checkly/projects/4/views/4) for an overview.
 
 Note: not all small updates and features will be tracked here; we regularly make small updates based on private feedback or our own discoveries and we'd rather ship them than create and close tickets here.
 


### PR DESCRIPTION
Minor fix: Change the link to the new kanban board. 